### PR TITLE
Add additionalHashContent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,13 @@ module.exports = {
 
 ## Options
 
-```javascript
-additionalHashContent: function(chunk) { return 'your additional content to hash'; } # a callback to add more content to the resulting hash
-algorithm: 'md5' # which algorithm to use (https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm)
-digest:    'hex' # which digest to use (https://nodejs.org/api/crypto.html#crypto_hash_digest_encoding)
+```
+// a callback to add more content to the resulting hash
+additionalHashContent: function(chunk) { return 'your additional content to hash'; } 
+// which algorithm to use (https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm)
+algorithm: 'md5'
+// which digest to use (https://nodejs.org/api/crypto.html#crypto_hash_digest_encoding)
+digest:    'hex'
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ module.exports = {
 
 ```
 
+## Options
+
+```javascript
+additionalHashContent: function(chunk) { return 'your additional content to hash'; } # a callback to add more content to the resulting hash
+algorithm: 'md5' # which algorithm to use (https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm)
+digest:    'hex' # which digest to use (https://nodejs.org/api/crypto.html#crypto_hash_digest_encoding)
+```
+
 ## License
 
 WebpackChunkHash plugin is released under the [MIT](License) license.

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ function WebpackChunkHash(options)
 
   this.algorithm = options.algorithm || 'md5';
   this.digest = options.digest || 'hex';
+  this.additionalHashContent = options.additionalHashContent || function() { return ''; };
 }
 
 WebpackChunkHash.prototype.apply = function(compiler)
@@ -19,7 +20,7 @@ WebpackChunkHash.prototype.apply = function(compiler)
     compilation.plugin('chunk-hash', function(chunk, chunkHash)
     {
       var source = chunk.modules.map(getModuleSource).sort(sortById).reduce(concatenateSource, '')
-        , hash   = crypto.createHash(_plugin.algorithm).update(source)
+        , hash   = crypto.createHash(_plugin.algorithm).update(source + _plugin.additionalHashContent(chunk))
         ;
 
       chunkHash.digest = function(digest)


### PR DESCRIPTION
We over at https://github.com/quizlet have the need to add additional content to the chunkhash value so that it updates properly. For example, changing UglifyJs options can change the output of a bundle but not the resulting filename produced by webpack.