### PR TITLE
Update to chunk.mapModules

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ WebpackChunkHash.prototype.apply = function(compiler)
   {
     compilation.plugin('chunk-hash', function(chunk, chunkHash)
     {
-      var source = chunk.modules.map(getModuleSource).sort(sortById).reduce(concatenateSource, '')
+      var modules = chunk.mapModules ? chunk.mapModules(getModuleSource) : chunk.modules.map(getModuleSource)
+      var source = modules.sort(sortById).reduce(concatenateSource, '')
         , hash   = crypto.createHash(_plugin.algorithm).update(source + _plugin.additionalHashContent(chunk))
         ;
 


### PR DESCRIPTION
Chunk.modules is deprecated in Webpack 3.0.0 - replaced with the mapModules method.
Added with fallback, to support Webpack 2.0.0