### PR TITLE
Fix webpack 4 deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,11 +15,40 @@ WebpackChunkHash.prototype.apply = function(compiler)
 {
   var _plugin = this;
 
-  compiler.plugin('compilation', function(compilation)
-  {
-    compilation.plugin('chunk-hash', function(chunk, chunkHash)
+  var compilerPlugin;
+  var compilationPlugin;
+  if (compiler.hooks) {
+    compilerPlugin = function (fn)
     {
-      var modules = chunk.mapModules ? chunk.mapModules(getModuleSource) : chunk.modules.map(getModuleSource)
+      compiler.hooks.compilation.tap('WebpackChunkHash', fn);
+    };
+    compilationPlugin = function (compilation, fn)
+    {
+      compilation.hooks.chunkHash.tap('WebpackChunkHash', fn);
+    }
+  } else {
+    compilerPlugin = function (fn)
+    {
+      compiler.plugin('compilation', fn);
+    };
+    compilationPlugin = function (compilation, fn)
+    {
+      compilation.plugin('chunk-hash', fn);
+    }
+  }
+
+  compilerPlugin(function(compilation)
+  {
+    compilationPlugin(compilation, function(chunk, chunkHash)
+    {
+      var modules;
+      if (chunk.modulesIterable) {
+        modules = Array.from(chunk.modulesIterable, getModuleSource);
+      } else if (chunk.mapModules) {
+        modules = chunk.mapModules(getModuleSource);
+      } else {
+        modules = chunk.modules.map(getModuleSource);
+      }
       var source = modules.sort(sortById).reduce(concatenateSource, '')
         , hash   = crypto.createHash(_plugin.algorithm).update(source + _plugin.additionalHashContent(chunk))
         ;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Alex Indigo <iam@alexindigo.com>",
   "license": "MIT",
   "dependencies": {
-    "@types/webpack": "^3.0.5"
+    "@types/webpack": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "argparse": "^1.0.4",


### PR DESCRIPTION
Ref #17 

This change fixes deprecation warnings with Webpack 4:
```
DeprecationWarning: Chunk.mapModules: Use Array.from(chunk.modulesIterable, fn) instead
DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
```

I think this plugin is still generally necessary and would like to see it in Webpack 4.  I believe hashing is still a problem with Webpack out of the box and this plugin provides a consistent hashing mechanism.

See https://github.com/webpack/webpack/issues/1479.  There is still a lot of discussion on getting Webpack hashing to work properly.